### PR TITLE
fixed uri.resolve transpiling

### DIFF
--- a/dist/Requester.js
+++ b/dist/Requester.js
@@ -10,7 +10,9 @@ Object.defineProperty(exports, '__esModule', {
   value: true
 });
 
-var _resolve = require('url');
+var _url = require('url');
+
+var _url2 = _interopRequireDefault(_url);
 
 var _LRUCache = require('lru-cache');
 
@@ -65,7 +67,7 @@ exports['default'] = function (Request) {
     }, {
       key: '_resolve',
       value: function _resolve(path) {
-        return _resolve.resolve(this._base, path);
+        return _url2['default'].resolve(this._base, path);
       }
     }, {
       key: 'GET',

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "babel": "^5.1.13",
-    "bluebird": "^2.9.24",
+    "bluebird": "^2.9.25",
     "immutable": "^3.7.2",
     "lodash": "^3.7.0",
     "lru-cache": "^2.6.2",

--- a/src/Requester.js
+++ b/src/Requester.js
@@ -1,4 +1,4 @@
-import { resolve } from 'url';
+import url from 'url';
 import LRUCache from 'lru-cache';
 import sigmund from 'sigmund';
 
@@ -25,7 +25,7 @@ export default (Request) => {
     }
 
     _resolve(path) {
-      return resolve(this._base, path);
+      return url.resolve(this._base, path);
     }
 
     GET(path, opts = {}) { // Cache GET requests as much as possible


### PR DESCRIPTION
Insert a workaround about `babel@5.1.13` bug causing `uri.resolve` and `_resolve` to have the same name in transpiled files.
